### PR TITLE
Ensure that VersionRange is immutable and hashable

### DIFF
--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -40,10 +40,13 @@ class VersionRange:
 
     # A list of lists of VersionConstraint that are signposts on the versions
     # timeline
-    constraints = attr.ib(type=tuple, converter=tuple, default=attr.Factory(tuple))
+    constraints = attr.ib(type=tuple, default=attr.Factory(tuple))
 
     def __attrs_post_init__(self, *args, **kwargs):
-        self.constraints.sort()
+        constraints = tuple(sorted(self.constraints))
+        # Notes: setattr is used because this is an immutable frozen instance.
+        # See https://www.attrs.org/en/stable/init.html?#post-init
+        object.__setattr__(self, "constraints", constraints)
 
     @classmethod
     def from_native(cls, string):

--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -40,7 +40,7 @@ class VersionRange:
 
     # A list of lists of VersionConstraint that are signposts on the versions
     # timeline
-    constraints = attr.ib(type=list, default=attr.Factory(list))
+    constraints = attr.ib(type=tuple, converter=tuple, default=attr.Factory(tuple))
 
     def __attrs_post_init__(self, *args, **kwargs):
         self.constraints.sort()

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -41,7 +41,7 @@ class TestVersionRange(TestCase):
         version_range = VersionRange.from_string(vers)
         assert version_range.scheme == "pypi"
         # note the sorting taking place
-        expected = [
+        expected = (
             VersionConstraint(comparator="=", version=PypiVersion(string="0.0.0")),
             VersionConstraint(comparator="=", version=PypiVersion(string="0.0.1")),
             VersionConstraint(comparator="=", version=PypiVersion(string="0.0.2")),
@@ -49,7 +49,7 @@ class TestVersionRange(TestCase):
             VersionConstraint(comparator="=", version=PypiVersion(string="0.0.4")),
             VersionConstraint(comparator="=", version=PypiVersion(string="0.0.5")),
             VersionConstraint(comparator="=", version=PypiVersion(string="0.0.6")),
-        ]
+        )
         assert version_range.constraints == expected
         # note the sorting taking place
         assert str(version_range) == "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|0.0.4|0.0.5|0.0.6"
@@ -146,7 +146,7 @@ class TestVersionRange(TestCase):
         gem_range = "~>2.0.8"
         version_range = GemVersionRange.from_native(gem_range)
         assert version_range.to_string() == "vers:gem/>=2.0.8|<2.1"
-        assert version_range.constraints == [
+        assert version_range.constraints == (
             VersionConstraint(comparator=">=", version=RubygemsVersion(string="2.0.8")),
             VersionConstraint(comparator="<", version=RubygemsVersion(string="2.1")),
-        ]
+        )


### PR DESCRIPTION
See #20
We now ensure that a `version_constraints` attribute is a tuple 

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>