### PR TITLE
Fix VersionRange crash on not in range versions

### DIFF
--- a/src/univers/version_constraint.py
+++ b/src/univers/version_constraint.py
@@ -444,19 +444,19 @@ def contains_version(version, constraints):
     if len(constraints) == 1:
         return version in constraints[0]
 
-    # If the "tested version" is equal to the any of the constraint version
-    # where the constraint comparator is for equality (any of "=", "<=", or ">=")
-    # then the "tested version" is in the range. Check is finished.
-    for constraint in constraints:
-        if "=" in constraint.comparator and version == constraint.version:
-            return True
-
     # If the "tested version" is equal to the any of the constraint version where
     # the constraint comparator is "=!" then the "tested version" is NOT in the
     # range. Check is finished.
     for constraint in constraints:
         if "!=" in constraint.comparator and version == constraint.version:
             return False
+
+    # If the "tested version" is equal to the any of the constraint version
+    # where the constraint comparator is for equality (any of "=", "<=", or ">=")
+    # then the "tested version" is in the range. Check is finished.
+    for constraint in constraints:
+        if "=" in constraint.comparator and version == constraint.version:
+            return True
 
     # Split the constraint list in two sub lists:
     #   a first list where the comparator is "=" or "!="
@@ -487,13 +487,9 @@ def contains_version(version, constraints):
         # and the "tested version" is greater than the current version
         # and the "tested version" is less than the next version
         # then the "tested version" is IN the range. Check is finished.
-        if (
-            cur_comp in (">", ">=")
-            and nxt_comp in ("<", "<=")
-            and version > cur_constraint.version
-            and version < nxt_constraint.version
-        ):
-            return True
+        if cur_comp in (">", ">=") and nxt_comp in ("<", "<="):
+            if version > cur_constraint.version and version < nxt_constraint.version:
+                return True
 
         # If current comparator is "<" or <=" and next comparator is ">" or >="
         # then these versions are out the range. Continue to the next iteration.

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -27,14 +27,48 @@ class TestVersionRange(TestCase):
         # note the sorting taking place
         assert str(version_range) == "vers:pypi/>=0.0.0|0.0.1|0.0.2|0.0.3|0.0.4|0.0.5|0.0.6"
 
-    def test_VersionRange_not_contains(self):
+    def test_VersionRange_pypi_does_not_contain_basic(self):
         vers = "vers:pypi/0.0.2|0.0.6|>=0.0.0|0.0.1|0.0.4|0.0.5|0.0.3"
         version_range = VersionRange.from_string(vers)
         assert not version_range.contains(PypiVersion("2.0.3"))
 
-    def test_VersionRange_contains(self):
+    def test_VersionRange_does_not_contain_version_after_range(self):
+        vers = "vers:pypi/>=1.0.0|<=2.0.0"
+        version_range = VersionRange.from_string(vers)
+        assert not version_range.contains(PypiVersion("2.0.3"))
+
+    def test_VersionRange_does_not_contain_version_before_range(self):
+        vers = "vers:pypi/>=1.0.0|<=2.0.0"
+        version_range = VersionRange.from_string(vers)
+        assert not version_range.contains(PypiVersion("0.0.9"))
+
+    def test_VersionRange_does_not_contain_version_in_between(self):
+        vers = "vers:pypi/<=1.0.0|>=2.0.0"
+        version_range = VersionRange.from_string(vers)
+        assert not version_range.contains(PypiVersion("1.5"))
+
+    def test_VersionRange_does_not_contain_version_excluded(self):
+        vers = "vers:pypi/>=3.0.0|!=2.0.3"
+        version_range = VersionRange.from_string(vers)
+        assert not version_range.contains(PypiVersion("2.0.3"))
+
+    def test_VersionRange_contains_version_after(self):
         version_range = VersionRange.from_string("vers:pypi/>0.0.2")
         assert PypiVersion("0.0.3") in version_range
+
+    def test_VersionRange_contains_version_before(self):
+        version_range = VersionRange.from_string("vers:pypi/<0.0.2")
+        assert PypiVersion("0.0.0.1") in version_range
+
+    def test_VersionRange_contains_version_included(self):
+        vers = "vers:pypi/>=3.0.0|2.0.3"
+        version_range = VersionRange.from_string(vers)
+        assert version_range.contains(PypiVersion("2.0.3"))
+
+    def test_VersionRange_contains_version_in_between(self):
+        vers = "vers:pypi/>=1.0.0|<=2.0.0"
+        version_range = VersionRange.from_string(vers)
+        assert version_range.contains(PypiVersion("1.5"))
 
     def test_VersionRange_from_string_pypi(self):
         vers = "vers:pypi/0.0.2|0.0.6|0.0.0|0.0.1|0.0.4|0.0.5|0.0.3"


### PR DESCRIPTION
Earlier, the check for whether the pairwise version constraints is in a
valid sequence and if the given version is in that pairwise range was
performed in a single condition. Upon failing the later case, it assumed
the failure of earlier as well and crashed.
Now, the later check is performed within the former condition.

Also, the check for != before looking for any constraint with a "="
avoids matching "!=" in the later case.

Fixes: https://github.com/nexB/univers/issues/25

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>