### PR TITLE
Fix for NpmVersionRange.from_native and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ Compare two native Python versions:
 
 .. code:: python
 
-    from univers.version import PypiVersion
+    from univers.versions import PypiVersion
     assert PypiVersion("1.2.3") < PypiVersion("1.2.4")
 
 
@@ -156,7 +156,7 @@ Test if a version is within or outside a version range:
 
 .. code:: python
 
-    from univers.version import PypiVersion
+    from univers.versions import PypiVersion
     from univers.version_range import VersionRange
 
     range = VersionRange.from_string("vers:pypi/>=1.2.4")
@@ -170,7 +170,7 @@ Development
 
 Run these commands, starting from a git clone of https://github.com/nexB/univers ::
 
-    $ configure --dev
+    $ ./configure --dev
     $ source venv/bin/active
     $ pytest -vvs
 

--- a/src/univers/version_range.py
+++ b/src/univers/version_range.py
@@ -234,10 +234,10 @@ class NpmVersionRange(VersionRange):
         anyof_constraints = []
         if isinstance(clause, AnyOf):
             for allof_clause in clause.clauses:
-                anyof_constraints.append(get_allof_constraints(cls, allof_clause))
+                anyof_constraints.extend(get_allof_constraints(cls, allof_clause))
         elif isinstance(clause, AllOf):
             alloc = get_allof_constraints(cls, clause)
-            anyof_constraints.append(alloc)
+            anyof_constraints.extend(alloc)
         else:
             raise ValueError(f"Unknown clause type: {spec!r}")
 

--- a/tests/test_codestyle.py
+++ b/tests/test_codestyle.py
@@ -10,7 +10,7 @@ import unittest
 
 class BaseTests(unittest.TestCase):
     def test_codestyle(self):
-        args = "venv/bin/black --check -l 100 setup.py etc src tests docs"
+        args = "venv/bin/black --check -l 100 setup.py src tests"
         try:
             subprocess.check_output(args.split())
         except subprocess.CalledProcessError as e:
@@ -19,6 +19,6 @@ class BaseTests(unittest.TestCase):
             print("===========================================================")
             raise Exception(
                 "Black style check failed; please format the code using:\n"
-                "  python -m black -l 100 setup.py etc src tests docs",
+                "  python -m black -l 100 setup.py src tests",
                 e.output,
             ) from e

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -13,8 +13,10 @@ from univers.version_range import InvalidVersionRange
 from univers.version_range import PypiVersionRange
 from univers.version_range import VersionRange
 from univers.version_range import RANGE_CLASS_BY_SCHEMES
+from univers.version_range import NpmVersionRange
 from univers.versions import PypiVersion
 from univers.versions import RubygemsVersion
+from univers.versions import SemverVersion
 
 
 class TestVersionRange(TestCase):
@@ -209,9 +211,32 @@ class TestVersionRange(TestCase):
         except InvalidVersionRange as ivre:
             assert str(ivre).startswith("Unsupported character")
 
+    def test_NpmVersionRange_from_native_with_compatible_with_version_operator(self):
+        npm_range = "^1.2.9"
+        expected = NpmVersionRange(
+            constraints=(
+                VersionConstraint(comparator=">=", version=SemverVersion(string="1.2.9")),
+                VersionConstraint(comparator="<", version=SemverVersion(string="2.0.0")),
+            )
+        )
+        version_range = NpmVersionRange.from_native(npm_range)
+        assert version_range == expected
+
+    def test_NpmVersionRange_from_native_with_approximately_equal_to_operator(self):
+        npm_range = "~3.8.2"
+        expected = NpmVersionRange(
+            constraints=(
+                VersionConstraint(comparator=">=", version=SemverVersion(string="3.8.2")),
+                VersionConstraint(comparator="<", version=SemverVersion(string="3.9.0")),
+            )
+        )
+        version_range = NpmVersionRange.from_native(npm_range)
+        assert version_range == expected
+
 
 VERSION_RANGE_TESTS_BY_SCHEME = {
     "nginx": ["0.8.40+", "0.7.52-0.8.39", "0.9.10", "1.5.0+, 1.4.1+"],
+    "npm": ["^1.2.9", "~3.8.2", "5.0.0 - 7.2.3", "2.1 || 2.6", "1.1.2 1.2.2", "<=2.1 >=1.1"],
 }
 
 


### PR DESCRIPTION
### 1. Fix `README` 

- Import `versions` instead `version`
     ```python
      [❌] from univers.version import PypiVersion
      [✅] from univers.versions import PypiVersion
   ```
- Use relative-path to execute configure script



### 2. Fix `NpmVersionRange`
- NpmVersionRange.from_native was returning a `tuple` containing `list of VersionConstraint`
- Instead it must return a `tuple` containing `VersionConstraint`

  - Earlier `NpmVersionRange.from_native("^1.0.2")` would return `constraints` as
     ```python
     ([VersionConstraint(comparator='<', version=SemverVersion(string='2.0.0')), VersionConstraint(comparator='>=', version=SemverVersion(string='1.0.2'))],)
    ```
   - After Fix
      ```python
      (VersionConstraint(comparator='>=', version=SemverVersion(string='1.0.2')), VersionConstraint(comparator='<', version=SemverVersion(string='2.0.0')))
     ```
- Fixes: https://github.com/nexB/univers/issues/35

### 3. Add test for `NpmVersionRange`
- `test_NpmVersionRange_from_native_with_compatible_with_version_operator`
- `test_NpmVersionRange_from_native_with_approximately_equal_to_operator`

### 4. Don't do black codestyle test for `docs` and `etc`
- codestyle test for `etc` to be handled by `skeleton`
- see: https://github.com/nexB/skeleton/issues/54

Signed-off-by: keshav-space <keshav6240@gmail.com>