### PR TITLE
Make tests work when not using virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ python:
   - "3.9"
 
 # Scripts to run at install stage
-install: ./configure --dev
+install: |
+  ./configure --dev
+  source venv/bin/activate
 
 # Scripts to run at script stage
-script: venv/bin/pytest
+script: pytest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,9 @@ jobs:
           image_name: ubuntu-18.04
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
-              all: venv/bin/pytest -n 2 -vvs
+              all: |
+                source venv/bin/activate
+                pytest -n 2 -vvs
 
     - template: etc/ci/azure-posix.yml
       parameters:
@@ -21,7 +23,9 @@ jobs:
           image_name: ubuntu-20.04
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
-              all: venv/bin/pytest -n 2 -vvs
+              all: |
+                source venv/bin/activate
+                pytest -n 2 -vvs
 
     - template: etc/ci/azure-posix.yml
       parameters:
@@ -29,7 +33,9 @@ jobs:
           image_name: macos-10.15
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
-              all: venv/bin/pytest -n 2 -vvs
+              all: |
+                source venv/bin/activate
+                pytest -n 2 -vvs
 
     - template: etc/ci/azure-posix.yml
       parameters:
@@ -37,7 +43,9 @@ jobs:
           image_name: macos-11
           python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
-              all: venv/bin/pytest -n 2 -vvs
+              all: |
+                source venv/bin/activate
+                pytest -n 2 -vvs
 
     - template: etc/ci/azure-win.yml
       parameters:
@@ -45,7 +53,9 @@ jobs:
           image_name: windows-2019
           python_versions: ['3.6', '3.7', '3.8', '3.9', '3.10']
           test_suites:
-              all: venv\Scripts\pytest -n 2 -vvs
+              all: |
+                call venv\Scripts\activate.bat
+                pytest -n 2 -vvs
 
     - template: etc/ci/azure-win.yml
       parameters:
@@ -53,4 +63,6 @@ jobs:
           image_name: windows-2022
           python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
-              all: venv\Scripts\pytest -n 2 -vvs
+              all: |
+                call venv\Scripts\activate.bat
+                pytest -n 2 -vvs

--- a/tests/test_codestyle.py
+++ b/tests/test_codestyle.py
@@ -10,7 +10,7 @@ import unittest
 
 class BaseTests(unittest.TestCase):
     def test_codestyle(self):
-        args = "venv/bin/black --check -l 100 setup.py src tests"
+        args = "black --check -l 100 setup.py src tests"
         try:
             subprocess.check_output(args.split())
         except subprocess.CalledProcessError as e:

--- a/tests/test_skeleton_codestyle.py
+++ b/tests/test_skeleton_codestyle.py
@@ -22,7 +22,7 @@ class BaseTests(unittest.TestCase):
         if setup_cfg["metadata"]["name"] != "skeleton":
             return
 
-        args = "venv/bin/black --check -l 100 setup.py etc tests"
+        args = "black --check -l 100 setup.py etc tests"
         try:
             subprocess.check_output(args.split())
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Currently, some of them explicitly reference black via its path inside
the virtual environment. In an environment where the venv is not used,
but rather the distribution’s packages are used for making the
dependencies like black available, this does not work. This changes it
to use the black binary from the PATH.

Since the official development guidelines document activating the
virtualenv before running pytest, which will make the black binary
available, it will still work when using the virtual environment.

The CI systems (Travis and Azure Pipelines) didn’t activate the
virtualenv but rather called pytest directly from the venv. This also
changes this so CI also works.